### PR TITLE
Fix Format of Request ID Header for Rack Applications

### DIFF
--- a/lib/timber-rack/util/request.rb
+++ b/lib/timber-rack/util/request.rb
@@ -10,8 +10,7 @@ module Timber
 
       REMOTE_IP_KEY_NAME = 'action_dispatch.remote_ip'.freeze
       REQUEST_ID_KEY_NAME1 = 'action_dispatch.request_id'.freeze
-      REQUEST_ID_KEY_NAME2 = 'X-Request-ID'.freeze
-      REQUEST_ID_KEY_NAME3 = 'X-Request-Id'.freeze
+      REQUEST_ID_KEY_NAME2 = 'HTTP_X_REQUEST_ID'.freeze
 
       def body_content
         content = body.read
@@ -57,8 +56,7 @@ module Timber
 
       def request_id
         @request_id ||= @env[REQUEST_ID_KEY_NAME1] ||
-          @env[REQUEST_ID_KEY_NAME2] ||
-          @env[REQUEST_ID_KEY_NAME3]
+          @env[REQUEST_ID_KEY_NAME2]
       end
     end
   end

--- a/spec/timber-rack/util/request_spec.rb
+++ b/spec/timber-rack/util/request_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe Timber::Util::Request do
       expect(req.headers).to eq({})
     end
   end
+
+  describe ".request_id" do
+    it "Returns Rack formatted http header" do
+      req = described_class.new({"HTTP_X_REQUEST_ID" => "12345"})
+      expect(req.request_id).to eq("12345")
+    end
+  end
 end


### PR DESCRIPTION
I noted the `request_id` attribute wasn't being included in my logs even though the other HTTPContext source attributes were. Looking into the implementation, I notice there are two keys used to look up the request id header, `X-Request-ID` and `X-Request-ID`. However, the lookup is done on the `@env` attribute of a piece of Rack middleware. 

Rack normalizes http request headers into the format `HTTP_...`. This is noted in the [rack specification](https://www.rubydoc.info/github/rack/rack/master/file/SPEC#label-The+Environment) (scroll down to the section labeled `HTTP_ Variables`). This means getting a copy of the request id requires using the key `HTTP_X_REQUEST_ID`. This PR replaces the un-normalized keys with this key and adds a unit test to confirm this behavior.

I initially tested this by setting `Timber::Config.instance.environment` to production (so I could see the json blob to be posted), and then running this command:
```
curl 'http://localhost:5000/' -H 'X-Request-ID: 12345ABC'
```

I've since deployed my app with the change contained in this PR and the request id is now being sent to Timber.